### PR TITLE
Handle hosts in the format of "hostname:port"

### DIFF
--- a/lib/aws.js
+++ b/lib/aws.js
@@ -103,12 +103,18 @@ var genericAWSClient = function(obj) {
       }
 
       var options = {
-        host: obj.host,
         path: obj.path,
         agent: obj.agent,
         method: 'POST',
         headers: headers
       };
+      // handle hosts in the format of "hostname:port"
+      if (obj.host.indexOf(":") > 0) {
+        options.host = obj.host.split(":")[0]
+        options.port = parseInt(obj.host.split(":")[1], 10)
+      } else {
+        options.host = obj.host
+      }
       var req = obj.connection.request(options, function (res) {
         var data = '';
         //the listener that handles the response chunks


### PR DESCRIPTION
Sometimes people use local AWS emulator for debugging/testing, so it is useful to support non-standard ports.

Thanks!