### PR TITLE
Update prodAdv.js

### DIFF
--- a/lib/prodAdv.js
+++ b/lib/prodAdv.js
@@ -19,13 +19,13 @@ function init(genericAWSClient) {
       call: call
     };
 
-    function call(action, query, callback) {
+    function call(action, query, host,callback) {
       query["Operation"] = action
       query["Service"] = "AWSECommerceService"
       query["Version"] = options.version || '2009-10-01'
       query["AssociateTag"] = associateTag;
       query["Region"] = options.region || "US"
-      return client.call(action, query, callback);
+      return client.call(action, query,host, callback);
     }
   }
 }


### PR DESCRIPTION
Amazon keeps many products country separated. And each different country has own end point address. For ex: for France, while end point address is "webservices.amazon.fr/onca/xml", for USA this adrress is "webservices.amazon.com/onca/xml". it can be checked at http://docs.aws.amazon.com/AWSECommerceService/latest/DG/AnatomyOfaRESTRequest.html.
So if this call method has selective host address option as a parameter, it will give us to flexibility when call product api, and no need to create new instance for requesting other amazon end points.
By this way, we need to just single instance for all amazons' end points.
this change on prodAdv.js requires some changes in aws.js.