### PR TITLE
Update aws.js

### DIFF
--- a/lib/aws.js
+++ b/lib/aws.js
@@ -52,7 +52,7 @@ function genericAWSClient(obj) {
 
   return {call: call};
 
-  function call(action, query, callback) {
+  function call(action, query, host,callback) {
     // Wrap the callback to prevent it from being called multiple times.
     callback = (function(next) {
       var isCalled = false;


### PR DESCRIPTION
Amazon keeps many products country separated. And each different country has own end point address. For ex: for France, while end point address is "webservices.amazon.fr/onca/xml", for USA this adrress is "webservices.amazon.com/onca/xml". it can be checked at http://docs.aws.amazon.com/AWSECommerceService/latest/DG/AnatomyOfaRESTRequest.html.
So if this call method has selective host address option as a parameter, it will give us to flexibility when call product api, and no need to create new instance for requesting other amazon end points.
By this way, we need to just single instance for all amazons' end points.
this change on aws.js  requires some changes in prodAdv.js.