### PR TITLE
check string pattern in data before parsed

### DIFF
--- a/lib/aws.js
+++ b/lib/aws.js
@@ -38,6 +38,12 @@ exports.createCFNClient = cfn.init(genericAWSClient);
 exports.createEMRClient = emr.init(genericAWSClient);
 exports.createMetaDataClient = metadata.init();
 
+function checkStringIsXML(data) {
+  var matcher = new RegExp('<?xml');
+  return data.match(matcher) ? true : false;
+}
+exports.checkStringIsXML = checkStringIsXML;
+
 // a generic AWS API Client which handles the general parts
 function genericAWSClient(obj) {
   var securityToken = obj.token;
@@ -102,7 +108,11 @@ function genericAWSClient(obj) {
                 callback(new Error('Unable to parse XML from AWS.'))
               }
             });
-            parser.parseString(data);
+            if (checkStringIsXML(data)) {
+              parser.parseString(data);
+            } else {
+              callback(new Error('Unable to parse XML from AWS.'))
+            }
           })
           res.addListener('error', callback)
         });

--- a/test/checkStringIsXML.js
+++ b/test/checkStringIsXML.js
@@ -1,0 +1,15 @@
+assert = require('assert');
+aws = require('../lib/aws');
+checkStringIsXML = aws.checkStringIsXML;
+xmlStringPattern = '<?xml version="1.0"?>';
+otherStringPattern = '<HTML>'
+
+describe('checkStringXML fn', function () {
+    it('should return true for string with xml patterns', function () {
+        console.log('testing check string is XML');
+        assert.equal(checkStringIsXML(xmlStringPattern), true);
+    });
+    it('should return false for string with other than xml pattern', function () {
+        assert.equal(checkStringIsXML(otherStringPattern), false);
+    });
+});


### PR DESCRIPTION
preventing node crashed when string pattern in data variable is not xml. Probably caused by Network Error, generally. 

Error Message: "The Web Server may be down, too busy, or experiencing other problems preventing it from responding to requests. You may wish to try again at a later time."